### PR TITLE
Fix SubjectPattern compile implementation

### DIFF
--- a/src/pattern/structure/subject_pattern.rs
+++ b/src/pattern/structure/subject_pattern.rs
@@ -43,7 +43,16 @@ impl Compilable for SubjectPattern {
                 code.push(Instr::NavigateSubject);
             }
             SubjectPattern::Pattern(pattern) => {
-                todo!();
+                // Navigate to the subject first so the resulting path
+                // includes the starting envelope and its subject.
+                code.push(Instr::NavigateSubject);
+                // Save the path and run the inner pattern relative to the
+                // subject. This mirrors the behaviour of SequencePattern so
+                // that any paths produced by `pattern` are appended to the
+                // subject path rather than replacing it.
+                code.push(Instr::ExtendSequence);
+                pattern.compile(code, literals);
+                code.push(Instr::CombineSequence);
             }
         }
     }


### PR DESCRIPTION
## Summary
- compile SubjectPattern::Pattern so the subject path is preserved
- ensure nested patterns operate relative to the subject

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6851376770608325b8f8631733885bc2