### PR TITLE
Add AND and sequence parsing

### DIFF
--- a/src/parse/parse_pattern.rs
+++ b/src/parse/parse_pattern.rs
@@ -1,11 +1,131 @@
 use logos::Logos;
 
 use super::Token;
-use crate::{Pattern, Result};
+use crate::{Error, Pattern, Result};
 
-pub fn parse_pattern(_input: impl AsRef<str>) -> Result<Pattern> {
-    let mut _lexer = Token::lexer(_input.as_ref());
-    todo!();
+/// Parse a pattern expression.
+///
+/// This handles a small subset of the grammar consisting of the `ANY`, `NONE`
+/// and `BOOL` primitives and the meta-pattern operators `&`, `>` and `|`.
+pub fn parse_pattern(input: impl AsRef<str>) -> Result<Pattern> {
+    let mut lexer = Token::lexer(input.as_ref());
+
+    let pattern = parse_or(&mut lexer)?;
+
+    match lexer.next() {
+        None => Ok(pattern),
+        Some(Ok(_)) => Err(Error::ExtraData(lexer.span())),
+        Some(Err(e)) => Err(e),
+    }
+}
+
+fn parse_or(lexer: &mut logos::Lexer<Token>) -> Result<Pattern> {
+    let mut patterns = vec![parse_sequence(lexer)?];
+
+    loop {
+        let mut lookahead = lexer.clone();
+        match lookahead.next() {
+            Some(Ok(Token::Or)) => {
+                // consume the '|'
+                lexer.next();
+                patterns.push(parse_sequence(lexer)?);
+            }
+            _ => break,
+        }
+    }
+
+    if patterns.len() == 1 {
+        Ok(patterns.remove(0))
+    } else {
+        Ok(Pattern::or(patterns))
+    }
+}
+
+fn parse_sequence(lexer: &mut logos::Lexer<Token>) -> Result<Pattern> {
+    let mut patterns = vec![parse_and(lexer)?];
+
+    loop {
+        let mut lookahead = lexer.clone();
+        match lookahead.next() {
+            Some(Ok(Token::Sequence)) => {
+                lexer.next();
+                patterns.push(parse_and(lexer)?);
+            }
+            _ => break,
+        }
+    }
+
+    if patterns.len() == 1 {
+        Ok(patterns.remove(0))
+    } else {
+        Ok(Pattern::sequence(patterns))
+    }
+}
+
+fn parse_and(lexer: &mut logos::Lexer<Token>) -> Result<Pattern> {
+    let mut patterns = vec![parse_primary(lexer)?];
+
+    loop {
+        let mut lookahead = lexer.clone();
+        match lookahead.next() {
+            Some(Ok(Token::And)) => {
+                lexer.next();
+                patterns.push(parse_primary(lexer)?);
+            }
+            _ => break,
+        }
+    }
+
+    if patterns.len() == 1 {
+        Ok(patterns.remove(0))
+    } else {
+        Ok(Pattern::and(patterns))
+    }
+}
+
+fn parse_primary(lexer: &mut logos::Lexer<Token>) -> Result<Pattern> {
+    let token = match lexer.next() {
+        Some(Ok(tok)) => tok,
+        Some(Err(e)) => return Err(e),
+        None => return Err(Error::UnexpectedEndOfInput),
+    };
+
+    match token {
+        Token::Any => Ok(Pattern::any()),
+        Token::None => Ok(Pattern::none()),
+        Token::Bool => parse_bool(lexer),
+        t => Err(Error::UnexpectedToken(Box::new(t), lexer.span())),
+    }
+}
+
+fn parse_bool(lexer: &mut logos::Lexer<Token>) -> Result<Pattern> {
+    let mut lookahead = lexer.clone();
+    match lookahead.next() {
+        Some(Ok(Token::ParenOpen)) => {
+            // consume '(' from the real lexer
+            lexer.next();
+
+            let value_token = match lexer.next() {
+                Some(Ok(tok)) => tok,
+                Some(Err(e)) => return Err(e),
+                None => return Err(Error::UnexpectedEndOfInput),
+            };
+
+            let value = match value_token {
+                Token::BoolTrue => true,
+                Token::BoolFalse => false,
+                t => return Err(Error::UnexpectedToken(Box::new(t), lexer.span())),
+            };
+
+            match lexer.next() {
+                Some(Ok(Token::ParenClose)) => Ok(Pattern::bool(value)),
+                Some(Ok(t)) => Err(Error::UnexpectedToken(Box::new(t), lexer.span())),
+                Some(Err(e)) => Err(e),
+                None => Err(Error::ExpectedCloseParen(lexer.span())),
+            }
+        }
+        _ => Ok(Pattern::any_bool()),
+    }
 }
 
 // #[cfg(test)]

--- a/tests/parse_tests.rs
+++ b/tests/parse_tests.rs
@@ -1,0 +1,127 @@
+use bc_envelope_pattern::{parse_pattern, Pattern};
+
+#[test]
+fn parse_any() {
+    let src = "ANY";
+    let p = parse_pattern(src).unwrap();
+    assert_eq!(p, Pattern::any());
+    assert_eq!(p.to_string(), src);
+}
+
+#[test]
+fn parse_none() {
+    let src = "NONE";
+    let p = parse_pattern(src).unwrap();
+    assert_eq!(p, Pattern::none());
+    assert_eq!(p.to_string(), src);
+}
+
+#[test]
+fn parse_bool_any() {
+    let src = "BOOL";
+    let p = parse_pattern(src).unwrap();
+    assert_eq!(p, Pattern::any_bool());
+    assert_eq!(p.to_string(), src);
+}
+
+#[test]
+fn parse_bool_true() {
+    let src = "BOOL(true)";
+    let p = parse_pattern(src).unwrap();
+    assert_eq!(p, Pattern::bool(true));
+    assert_eq!(p.to_string(), src);
+    let spaced = "BOOL ( true )";
+    let p_spaced = parse_pattern(spaced).unwrap();
+    assert_eq!(p_spaced, Pattern::bool(true));
+    assert_eq!(p_spaced.to_string(), src);
+}
+
+#[test]
+fn parse_bool_false() {
+    let src = "BOOL(false)";
+    let p = parse_pattern(src).unwrap();
+    assert_eq!(p, Pattern::bool(false));
+    assert_eq!(p.to_string(), src);
+    let spaced = "BOOL ( false )";
+    let p_spaced = parse_pattern(spaced).unwrap();
+    assert_eq!(p_spaced, Pattern::bool(false));
+    assert_eq!(p_spaced.to_string(), src);
+}
+
+#[test]
+fn parse_bool_or() {
+    let src = "BOOL(true)|BOOL(false)";
+    let p = parse_pattern(src).unwrap();
+    assert_eq!(
+        p,
+        Pattern::or(vec![Pattern::bool(true), Pattern::bool(false)])
+    );
+    assert_eq!(p.to_string(), src);
+
+    let spaced = "BOOL(true) | BOOL(false)";
+    let p_spaced = parse_pattern(spaced).unwrap();
+    assert_eq!(
+        p_spaced,
+        Pattern::or(vec![Pattern::bool(true), Pattern::bool(false)])
+    );
+    assert_eq!(p_spaced.to_string(), src);
+}
+
+#[test]
+fn parse_bool_and() {
+    let src = "BOOL(true)&BOOL(false)";
+    let p = parse_pattern(src).unwrap();
+    assert_eq!(
+        p,
+        Pattern::and(vec![Pattern::bool(true), Pattern::bool(false)])
+    );
+    assert_eq!(p.to_string(), src);
+
+    let spaced = "BOOL(true) & BOOL(false)";
+    let p_spaced = parse_pattern(spaced).unwrap();
+    assert_eq!(
+        p_spaced,
+        Pattern::and(vec![Pattern::bool(true), Pattern::bool(false)])
+    );
+    assert_eq!(p_spaced.to_string(), src);
+}
+
+#[test]
+fn parse_bool_sequence() {
+    let src = "BOOL(true)>BOOL(false)";
+    let p = parse_pattern(src).unwrap();
+    assert_eq!(
+        p,
+        Pattern::sequence(vec![Pattern::bool(true), Pattern::bool(false)])
+    );
+    assert_eq!(p.to_string(), src);
+
+    let spaced = "BOOL(true) > BOOL(false)";
+    let p_spaced = parse_pattern(spaced).unwrap();
+    assert_eq!(
+        p_spaced,
+        Pattern::sequence(vec![Pattern::bool(true), Pattern::bool(false)])
+    );
+    assert_eq!(p_spaced.to_string(), src);
+}
+
+#[test]
+fn parse_operator_precedence() {
+    let expr = "ANY > BOOL(true) & BOOL(false) > NONE | ANY > BOOL(true) & BOOL(false) > ANY";
+    let p = parse_pattern(expr).unwrap();
+
+    let left_seq = Pattern::sequence(vec![
+        Pattern::any(),
+        Pattern::and(vec![Pattern::bool(true), Pattern::bool(false)]),
+        Pattern::none(),
+    ]);
+    let right_seq = Pattern::sequence(vec![
+        Pattern::any(),
+        Pattern::and(vec![Pattern::bool(true), Pattern::bool(false)]),
+        Pattern::any(),
+    ]);
+    let expected = Pattern::or(vec![left_seq, right_seq]);
+
+    assert_eq!(p, expected);
+    assert_eq!(p.to_string(), "ANY>BOOL(true)&BOOL(false)>NONE|ANY>BOOL(true)&BOOL(false)>ANY");
+}


### PR DESCRIPTION
## Summary
- extend parser to support `&` and `>` operators with proper precedence
- add unit tests validating `AndPattern` and `SequencePattern` parsing
- include complex precedence test combining all operators
- verify `parse_pattern` round trips to canonical string representation

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6852330a209c83258aec9a0ba0683390