### PR TITLE
Implement Text and Number pattern parsing

### DIFF
--- a/src/parse/parse_pattern.rs
+++ b/src/parse/parse_pattern.rs
@@ -94,6 +94,8 @@ fn parse_primary(lexer: &mut logos::Lexer<Token>) -> Result<Pattern> {
         Token::Any => Ok(Pattern::any()),
         Token::None => Ok(Pattern::none()),
         Token::Bool => parse_bool(lexer),
+        Token::Text => parse_text(lexer),
+        Token::Number => parse_number(lexer),
         t => Err(Error::UnexpectedToken(Box::new(t), lexer.span())),
     }
 }
@@ -126,6 +128,188 @@ fn parse_bool(lexer: &mut logos::Lexer<Token>) -> Result<Pattern> {
         }
         _ => Ok(Pattern::any_bool()),
     }
+}
+
+fn parse_text(lexer: &mut logos::Lexer<Token>) -> Result<Pattern> {
+    let mut lookahead = lexer.clone();
+    match lookahead.next() {
+        Some(Ok(Token::ParenOpen)) => {
+            lexer.next();
+
+            let mut la = lexer.clone();
+            match la.next() {
+                Some(Ok(Token::Regex(_))) => {
+                    if let Some(Ok(Token::Regex(res))) = lexer.next() {
+                        let regex = regex::Regex::new(&res?).map_err(|_| Error::InvalidRegex(lexer.span()))?;
+                        match lexer.next() {
+                            Some(Ok(Token::ParenClose)) => Ok(Pattern::text_regex(regex)),
+                            Some(Ok(t)) => Err(Error::UnexpectedToken(Box::new(t), lexer.span())),
+                            Some(Err(e)) => Err(e),
+                            None => Err(Error::ExpectedCloseParen(lexer.span())),
+                        }
+                    } else {
+                        Err(Error::UnexpectedEndOfInput)
+                    }
+                }
+                _ => {
+                    let src = lexer.remainder();
+                    let (value, consumed) = parse_string_literal(src)?;
+                    lexer.bump(consumed);
+                    match lexer.next() {
+                        Some(Ok(Token::ParenClose)) => Ok(Pattern::text(value)),
+                        Some(Ok(t)) => Err(Error::UnexpectedToken(Box::new(t), lexer.span())),
+                        Some(Err(e)) => Err(e),
+                        None => Err(Error::ExpectedCloseParen(lexer.span())),
+                    }
+                }
+            }
+        }
+        _ => Ok(Pattern::any_text()),
+    }
+}
+
+fn parse_string_literal(src: &str) -> Result<(String, usize)> {
+    let mut pos = 0;
+    while let Some(ch) = src[pos..].chars().next() {
+        if matches!(ch, ' ' | '\t' | '\n' | '\r' | '\u{0c}') {
+            pos += ch.len_utf8();
+        } else {
+            break;
+        }
+    }
+
+    let bytes = src.as_bytes();
+    if pos >= bytes.len() || bytes[pos] != b'"' {
+        return Err(Error::UnexpectedEndOfInput);
+    }
+    pos += 1;
+    let start = pos;
+    let mut escape = false;
+    while pos < bytes.len() {
+        let b = bytes[pos];
+        pos += 1;
+        if escape {
+            escape = false;
+            continue;
+        }
+        if b == b'\\' {
+            escape = true;
+            continue;
+        }
+        if b == b'"' {
+            let inner = &src[start..pos - 1];
+            let value = inner.replace("\\\"", "\"").replace("\\\\", "\\");
+            while let Some(ch) = src[pos..].chars().next() {
+                if matches!(ch, ' ' | '\t' | '\n' | '\r' | '\u{0c}') {
+                    pos += ch.len_utf8();
+                } else {
+                    break;
+                }
+            }
+            return Ok((value, pos));
+        }
+    }
+    Err(Error::UnexpectedEndOfInput)
+}
+
+fn parse_number(lexer: &mut logos::Lexer<Token>) -> Result<Pattern> {
+    let mut lookahead = lexer.clone();
+    match lookahead.next() {
+        Some(Ok(Token::ParenOpen)) => {
+            lexer.next();
+
+            let src = lexer.remainder();
+            let (pattern, consumed) = parse_number_inner(src)?;
+            lexer.bump(consumed);
+
+            match lexer.next() {
+                Some(Ok(Token::ParenClose)) => Ok(pattern),
+                Some(Ok(t)) => Err(Error::UnexpectedToken(Box::new(t), lexer.span())),
+                Some(Err(e)) => Err(e),
+                None => Err(Error::ExpectedCloseParen(lexer.span())),
+            }
+        }
+        _ => Ok(Pattern::any_number()),
+    }
+}
+
+fn parse_uint_digits(src: &str, pos: &mut usize) -> Result<f64> {
+    let start = *pos;
+    while let Some(ch) = src[*pos..].chars().next() {
+        if ch.is_ascii_digit() {
+            *pos += ch.len_utf8();
+        } else {
+            break;
+        }
+    }
+    if start == *pos {
+        return Err(Error::InvalidNumberFormat(0..0));
+    }
+    src[start..*pos].parse::<f64>().map_err(|_| Error::InvalidNumberFormat(0..0))
+}
+
+fn skip_ws(src: &str, pos: &mut usize) {
+    while let Some(ch) = src[*pos..].chars().next() {
+        if matches!(ch, ' ' | '\t' | '\n' | '\r' | '\u{0c}') {
+            *pos += ch.len_utf8();
+        } else {
+            break;
+        }
+    }
+}
+
+fn parse_number_inner(src: &str) -> Result<(Pattern, usize)> {
+    let mut pos = 0;
+    skip_ws(src, &mut pos);
+
+    if src[pos..].starts_with("NaN") {
+        pos += 3;
+        skip_ws(src, &mut pos);
+        return Ok((Pattern::number_nan(), pos));
+    }
+
+    let cmp = if src[pos..].starts_with(">=") {
+        pos += 2;
+        Some("ge")
+    } else if src[pos..].starts_with("<=") {
+        pos += 2;
+        Some("le")
+    } else if src[pos..].starts_with('>') {
+        pos += 1;
+        Some("gt")
+    } else if src[pos..].starts_with('<') {
+        pos += 1;
+        Some("lt")
+    } else {
+        None
+    };
+
+    if let Some(tag) = cmp {
+        skip_ws(src, &mut pos);
+        let val = parse_uint_digits(src, &mut pos)?;
+        skip_ws(src, &mut pos);
+        let pattern = match tag {
+            "ge" => Pattern::number_greater_than_or_equal(val),
+            "le" => Pattern::number_less_than_or_equal(val),
+            "gt" => Pattern::number_greater_than(val),
+            "lt" => Pattern::number_less_than(val),
+            _ => unreachable!(),
+        };
+        return Ok((pattern, pos));
+    }
+
+    let first = parse_uint_digits(src, &mut pos)?;
+    skip_ws(src, &mut pos);
+
+    if src[pos..].starts_with("...") {
+        pos += 3;
+        skip_ws(src, &mut pos);
+        let second = parse_uint_digits(src, &mut pos)?;
+        skip_ws(src, &mut pos);
+        return Ok((Pattern::number_range(first..=second), pos));
+    }
+
+    Ok((Pattern::number(first), pos))
 }
 
 // #[cfg(test)]

--- a/tests/parse_tests.rs
+++ b/tests/parse_tests.rs
@@ -125,3 +125,64 @@ fn parse_operator_precedence() {
     assert_eq!(p, expected);
     assert_eq!(p.to_string(), "ANY>BOOL(true)&BOOL(false)>NONE|ANY>BOOL(true)&BOOL(false)>ANY");
 }
+
+#[test]
+fn parse_text_patterns() {
+    let p = parse_pattern("TEXT").unwrap();
+    assert_eq!(p, Pattern::any_text());
+    assert_eq!(p.to_string(), "TEXT");
+
+    let p = parse_pattern("TEXT(\"hello\")").unwrap();
+    assert_eq!(p, Pattern::text("hello"));
+    assert_eq!(p.to_string(), "TEXT(\"hello\")");
+
+    let spaced = "TEXT ( \"hello\" )";
+    let p_spaced = parse_pattern(spaced).unwrap();
+    assert_eq!(p_spaced, Pattern::text("hello"));
+    assert_eq!(p_spaced.to_string(), "TEXT(\"hello\")");
+
+    let p = parse_pattern("TEXT(/h.*o/)").unwrap();
+    let regex = regex::Regex::new("h.*o").unwrap();
+    assert_eq!(p, Pattern::text_regex(regex));
+    assert_eq!(p.to_string(), "TEXT(/h.*o/)");
+}
+
+#[test]
+fn parse_number_patterns() {
+    let p = parse_pattern("NUMBER").unwrap();
+    assert_eq!(p, Pattern::any_number());
+    assert_eq!(p.to_string(), "NUMBER");
+
+    let p = parse_pattern("NUMBER(42)").unwrap();
+    assert_eq!(p, Pattern::number(42));
+    assert_eq!(p.to_string(), "NUMBER(42)");
+
+    let spaced = "NUMBER ( 42 )";
+    let p_spaced = parse_pattern(spaced).unwrap();
+    assert_eq!(p_spaced, Pattern::number(42));
+    assert_eq!(p_spaced.to_string(), "NUMBER(42)");
+
+    let p = parse_pattern("NUMBER(1...3)").unwrap();
+    assert_eq!(p, Pattern::number_range(1..=3));
+    assert_eq!(p.to_string(), "NUMBER(1...3)");
+
+    let p = parse_pattern("NUMBER(>5)").unwrap();
+    assert_eq!(p, Pattern::number_greater_than(5));
+    assert_eq!(p.to_string(), "NUMBER(>5)");
+
+    let p = parse_pattern("NUMBER(>=5)").unwrap();
+    assert_eq!(p, Pattern::number_greater_than_or_equal(5));
+    assert_eq!(p.to_string(), "NUMBER(>=5)");
+
+    let p = parse_pattern("NUMBER(<5)").unwrap();
+    assert_eq!(p, Pattern::number_less_than(5));
+    assert_eq!(p.to_string(), "NUMBER(<5)");
+
+    let p = parse_pattern("NUMBER(<=5)").unwrap();
+    assert_eq!(p, Pattern::number_less_than_or_equal(5));
+    assert_eq!(p.to_string(), "NUMBER(<=5)");
+
+    let p = parse_pattern("NUMBER(NaN)").unwrap();
+    assert_eq!(p, Pattern::number_nan());
+    assert_eq!(p.to_string(), "NUMBER(NaN)");
+}


### PR DESCRIPTION
## Summary
- extend parser with Text and Number patterns
- support quoted strings, regex and numeric ranges/comparisons
- add unit tests for new parsing functionality
- verify to_string() round trips for number and text patterns

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6852522e9d9c8325bc89c116039ee931