### PR TITLE
Implement additional leaf pattern parsing

### DIFF
--- a/src/parse/parse_pattern.rs
+++ b/src/parse/parse_pattern.rs
@@ -96,6 +96,9 @@ fn parse_primary(lexer: &mut logos::Lexer<Token>) -> Result<Pattern> {
         Token::Bool => parse_bool(lexer),
         Token::Text => parse_text(lexer),
         Token::Number => parse_number(lexer),
+        Token::Leaf => Ok(Pattern::any_leaf()),
+        Token::Array => parse_array(lexer),
+        Token::ByteString => parse_byte_string(lexer),
         t => Err(Error::UnexpectedToken(Box::new(t), lexer.span())),
     }
 }
@@ -210,6 +213,116 @@ fn parse_string_literal(src: &str) -> Result<(String, usize)> {
         }
     }
     Err(Error::UnexpectedEndOfInput)
+}
+
+fn parse_array(lexer: &mut logos::Lexer<Token>) -> Result<Pattern> {
+    let mut lookahead = lexer.clone();
+    match lookahead.next() {
+        Some(Ok(Token::ParenOpen)) => {
+            lexer.next();
+            match lexer.next() {
+                Some(Ok(Token::Range(res))) => {
+                    let range = res?;
+                    let pat = if let Some(max) = range.max() {
+                        Pattern::array_with_range(range.min()..=max)
+                    } else {
+                        Pattern::array_with_range(range.min()..)
+                    };
+                    match lexer.next() {
+                        Some(Ok(Token::ParenClose)) => Ok(pat),
+                        Some(Ok(t)) => Err(Error::UnexpectedToken(Box::new(t), lexer.span())),
+                        Some(Err(e)) => Err(e),
+                        None => Err(Error::ExpectedCloseParen(lexer.span())),
+                    }
+                }
+                Some(Ok(t)) => Err(Error::UnexpectedToken(Box::new(t), lexer.span())),
+                Some(Err(e)) => Err(e),
+                None => Err(Error::UnexpectedEndOfInput),
+            }
+        }
+        _ => Ok(Pattern::any_array()),
+    }
+}
+
+fn parse_hex_string(src: &str) -> Result<(Vec<u8>, usize)> {
+    let mut pos = 0;
+    skip_ws(src, &mut pos);
+    if !src[pos..].starts_with("h'") {
+        return Err(Error::InvalidHexString(pos..pos));
+    }
+    pos += 2;
+    let start = pos;
+    while pos < src.len() {
+        let b = src.as_bytes()[pos];
+        if b == b'\'' {
+            let inner = &src[start..pos];
+            let bytes = hex::decode(inner).map_err(|_| Error::InvalidHexString(pos..pos))?;
+            pos += 1;
+            skip_ws(src, &mut pos);
+            return Ok((bytes, pos));
+        }
+        if !(b as char).is_ascii_hexdigit() {
+            return Err(Error::InvalidHexString(pos..pos));
+        }
+        pos += 1;
+    }
+    Err(Error::InvalidHexString(pos..pos))
+}
+
+fn parse_binary_regex(src: &str) -> Result<(regex::bytes::Regex, usize)> {
+    let mut pos = 0;
+    skip_ws(src, &mut pos);
+    if pos >= src.len() || src.as_bytes()[pos] != b'/' {
+        return Err(Error::UnterminatedRegex(pos..pos));
+    }
+    pos += 1;
+    let start = pos;
+    let mut escape = false;
+    while pos < src.len() {
+        let b = src.as_bytes()[pos];
+        pos += 1;
+        if escape {
+            escape = false;
+            continue;
+        }
+        if b == b'\\' {
+            escape = true;
+            continue;
+        }
+        if b == b'/' {
+            let inner = &src[start..pos - 1];
+            let regex = regex::bytes::Regex::new(inner)
+                .map_err(|_| Error::InvalidRegex(pos..pos))?;
+            skip_ws(src, &mut pos);
+            return Ok((regex, pos));
+        }
+    }
+    Err(Error::UnterminatedRegex(pos..pos))
+}
+
+fn parse_byte_string(lexer: &mut logos::Lexer<Token>) -> Result<Pattern> {
+    let mut lookahead = lexer.clone();
+    match lookahead.next() {
+        Some(Ok(Token::ParenOpen)) => {
+            lexer.next();
+            let src = lexer.remainder();
+            let (pattern, consumed) = if src.trim_start().starts_with('/') {
+                let (regex, used) = parse_binary_regex(src)?;
+                (Pattern::byte_string_binary_regex(regex), used)
+            } else {
+                let (bytes, used) = parse_hex_string(src)?;
+                (Pattern::byte_string(bytes), used)
+            };
+            lexer.bump(consumed);
+            match lexer.next() {
+                Some(Ok(Token::ParenClose)) => Ok(pattern),
+                Some(Ok(t)) => Err(Error::UnexpectedToken(Box::new(t), lexer.span())),
+                Some(Err(e)) => Err(e),
+                None => Err(Error::ExpectedCloseParen(lexer.span())),
+            }
+        }
+        _ => Ok(Pattern::any_byte_string()),
+    }
 }
 
 fn parse_number(lexer: &mut logos::Lexer<Token>) -> Result<Pattern> {

--- a/src/parse/token.rs
+++ b/src/parse/token.rs
@@ -101,6 +101,9 @@ pub enum Token {
     #[token("BSTR")]
     ByteString,
 
+    #[token("LEAF")]
+    Leaf,
+
     #[token("CBOR")]
     Cbor,
 

--- a/src/pattern/leaf/array_pattern.rs
+++ b/src/pattern/leaf/array_pattern.rs
@@ -58,18 +58,7 @@ impl std::fmt::Display for ArrayPattern {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ArrayPattern::Any => write!(f, "ARRAY"),
-            ArrayPattern::Interval(range) => {
-                if range.is_single() {
-                    write!(f, "ARRAY({{{}}})", range.min())
-                } else {
-                    write!(
-                        f,
-                        "ARRAY({{{}}},{{{}}})",
-                        range.min(),
-                        range.max().unwrap()
-                    )
-                }
-            }
+            ArrayPattern::Interval(range) => write!(f, "ARRAY({})", range),
         }
     }
 }

--- a/tests/parse_tests.rs
+++ b/tests/parse_tests.rs
@@ -187,3 +187,45 @@ fn parse_number_patterns() {
     assert_eq!(p, Pattern::number_nan());
     assert_eq!(p.to_string(), "NUMBER(NaN)");
 }
+
+#[test]
+fn parse_leaf_pattern() {
+    let p = parse_pattern("LEAF").unwrap();
+    assert_eq!(p, Pattern::any_leaf());
+    assert_eq!(p.to_string(), "LEAF");
+}
+
+#[test]
+fn parse_array_patterns() {
+    let p = parse_pattern("ARRAY").unwrap();
+    assert_eq!(p, Pattern::any_array());
+    assert_eq!(p.to_string(), "ARRAY");
+
+    let p = parse_pattern("ARRAY({3})").unwrap();
+    assert_eq!(p, Pattern::array_with_count(3));
+    assert_eq!(p.to_string(), "ARRAY({3})");
+
+    let p = parse_pattern("ARRAY({2,4})").unwrap();
+    assert_eq!(p, Pattern::array_with_range(2..=4));
+    assert_eq!(p.to_string(), "ARRAY({2,4})");
+
+    let p = parse_pattern("ARRAY({2,})").unwrap();
+    assert_eq!(p, Pattern::array_with_range(2..));
+    assert_eq!(p.to_string(), "ARRAY({2,})");
+}
+
+#[test]
+fn parse_bstr_patterns() {
+    let p = parse_pattern("BSTR").unwrap();
+    assert_eq!(p, Pattern::any_byte_string());
+    assert_eq!(p.to_string(), "BSTR");
+
+    let p = parse_pattern("BSTR(h'0102')").unwrap();
+    assert_eq!(p, Pattern::byte_string(vec![1u8, 2]));
+    assert_eq!(p.to_string(), "BSTR(h'0102')");
+
+    let p = parse_pattern("BSTR(/abc/)").unwrap();
+    let regex = regex::bytes::Regex::new("abc").unwrap();
+    assert_eq!(p, Pattern::byte_string_binary_regex(regex));
+    assert_eq!(p.to_string(), "BSTR(/abc/)");
+}


### PR DESCRIPTION
## Summary
- add `LEAF` token
- parse `LEAF`, `ARRAY`, and `BSTR` patterns
- support hex and binary regex byte string patterns
- clean up array display formatting
- test new parser features

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685259952b5483259568163a5977b5a1