### PR TITLE
Implement tagged and known value parsing

### DIFF
--- a/src/parse/leaf/mod.rs
+++ b/src/parse/leaf/mod.rs
@@ -2,6 +2,7 @@
 
 use super::{Token, utils};
 use crate::{Error, Pattern, Result};
+use known_values::KnownValue;
 
 pub(crate) fn parse_bool(lexer: &mut logos::Lexer<Token>) -> Result<Pattern> {
     let mut lookahead = lexer.clone();
@@ -240,6 +241,80 @@ pub(crate) fn parse_map(lexer: &mut logos::Lexer<Token>) -> Result<Pattern> {
             }
         }
         _ => Ok(Pattern::any_map()),
+    }
+}
+
+pub(crate) fn parse_tag(lexer: &mut logos::Lexer<Token>) -> Result<Pattern> {
+    let mut lookahead = lexer.clone();
+    match lookahead.next() {
+        Some(Ok(Token::ParenOpen)) => {
+            lexer.next();
+            let src = lexer.remainder();
+            let (pattern, consumed) = parse_tag_inner(src)?;
+            lexer.bump(consumed);
+            match lexer.next() {
+                Some(Ok(Token::ParenClose)) => Ok(pattern),
+                Some(Ok(t)) => Err(Error::UnexpectedToken(Box::new(t), lexer.span())),
+                Some(Err(e)) => Err(e),
+                None => Err(Error::ExpectedCloseParen(lexer.span())),
+            }
+        }
+        _ => Ok(Pattern::any_tag()),
+    }
+}
+
+fn parse_tag_inner(src: &str) -> Result<(Pattern, usize)> {
+    let mut pos = 0;
+    utils::skip_ws(src, &mut pos);
+    if src[pos..].starts_with('/') {
+        let (regex, used) = utils::parse_text_regex(&src[pos..])?;
+        pos += used;
+        return Ok((Pattern::tagged_with_regex(regex), pos));
+    }
+
+    let (word, used) = utils::parse_bare_word(&src[pos..])?;
+    pos += used;
+    if let Ok(value) = word.parse::<u64>() {
+        Ok((Pattern::tagged_with_value(value), pos))
+    } else {
+        Ok((Pattern::tagged_with_name(word), pos))
+    }
+}
+
+pub(crate) fn parse_known_value(lexer: &mut logos::Lexer<Token>) -> Result<Pattern> {
+    let mut lookahead = lexer.clone();
+    match lookahead.next() {
+        Some(Ok(Token::ParenOpen)) => {
+            lexer.next();
+            let src = lexer.remainder();
+            let (pattern, consumed) = parse_known_value_inner(src)?;
+            lexer.bump(consumed);
+            match lexer.next() {
+                Some(Ok(Token::ParenClose)) => Ok(pattern),
+                Some(Ok(t)) => Err(Error::UnexpectedToken(Box::new(t), lexer.span())),
+                Some(Err(e)) => Err(e),
+                None => Err(Error::ExpectedCloseParen(lexer.span())),
+            }
+        }
+        _ => Ok(Pattern::any_known_value()),
+    }
+}
+
+fn parse_known_value_inner(src: &str) -> Result<(Pattern, usize)> {
+    let mut pos = 0;
+    utils::skip_ws(src, &mut pos);
+    if src[pos..].starts_with('/') {
+        let (regex, used) = utils::parse_text_regex(&src[pos..])?;
+        pos += used;
+        return Ok((Pattern::known_value_regex(regex), pos));
+    }
+
+    let (inner, used) = utils::parse_single_quoted(&src[pos..])?;
+    pos += used;
+    if let Ok(value) = inner.parse::<u64>() {
+        Ok((Pattern::known_value(KnownValue::new(value)), pos))
+    } else {
+        Ok((Pattern::known_value_named(inner), pos))
     }
 }
 

--- a/src/parse/meta/mod.rs
+++ b/src/parse/meta/mod.rs
@@ -82,6 +82,8 @@ fn parse_primary(lexer: &mut logos::Lexer<Token>) -> Result<Pattern> {
         Token::Bool => leaf::parse_bool(lexer),
         Token::ByteString => leaf::parse_byte_string(lexer),
         Token::Date => leaf::parse_date(lexer),
+        Token::Tag => leaf::parse_tag(lexer),
+        Token::Known => leaf::parse_known_value(lexer),
         Token::Leaf => Ok(Pattern::any_leaf()),
         Token::Map => leaf::parse_map(lexer),
         Token::None => Ok(Pattern::none()),

--- a/tests/parse_tests.rs
+++ b/tests/parse_tests.rs
@@ -1,4 +1,5 @@
 use bc_envelope_pattern::{Pattern, parse_pattern};
+use known_values::KnownValue;
 
 #[test]
 fn parse_any() {
@@ -291,4 +292,44 @@ fn parse_null_pattern() {
     let p = parse_pattern("NULL").unwrap();
     assert_eq!(p, Pattern::null());
     assert_eq!(p.to_string(), "NULL");
+}
+
+#[test]
+fn parse_tag_patterns() {
+    let p = parse_pattern("TAG").unwrap();
+    assert_eq!(p, Pattern::any_tag());
+    assert_eq!(p.to_string(), "TAG");
+
+    let p = parse_pattern("TAG(100)").unwrap();
+    assert_eq!(p, Pattern::tagged_with_value(100));
+    assert_eq!(p.to_string(), "TAG(100)");
+
+    let p = parse_pattern("TAG(date)").unwrap();
+    assert_eq!(p, Pattern::tagged_with_name("date"));
+    assert_eq!(p.to_string(), "TAG(date)");
+
+    let p = parse_pattern("TAG(/da.*/)").unwrap();
+    let regex = regex::Regex::new("da.*").unwrap();
+    assert_eq!(p, Pattern::tagged_with_regex(regex));
+    assert_eq!(p.to_string(), "TAG(/da.*/)");
+}
+
+#[test]
+fn parse_known_value_patterns() {
+    let p = parse_pattern("KNOWN").unwrap();
+    assert_eq!(p, Pattern::any_known_value());
+    assert_eq!(p.to_string(), "KNOWN");
+
+    let p = parse_pattern("KNOWN('1')").unwrap();
+    assert_eq!(p, Pattern::known_value(KnownValue::new(1)));
+    assert_eq!(p.to_string(), "KNOWN(1)");
+
+    let p = parse_pattern("KNOWN('date')").unwrap();
+    assert_eq!(p, Pattern::known_value_named("date"));
+    assert_eq!(p.to_string(), "KNOWN(date)");
+
+    let p = parse_pattern("KNOWN(/da.*/)").unwrap();
+    let regex = regex::Regex::new("da.*").unwrap();
+    assert_eq!(p, Pattern::known_value_regex(regex));
+    assert_eq!(p.to_string(), "KNOWN(/da.*/)");
 }


### PR DESCRIPTION
## Summary
- parse `TAG()` patterns and map to pattern constructors
- parse `KNOWN()` patterns with bare names, quoted names, numbers, or regex
- add helper functions for bare words and single-quoted strings
- extend meta parsing to recognize `TAG` and `KNOWN` keywords
- test parsing for tag and known-value patterns
- require single quotes around numbers and names in `KNOWN()` patterns

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685266c0f92883258033cb661197c7cf