### PR TITLE
Implement CBOR pattern parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ hex-literal = "^0.4.1"
 indoc = "^2.0.0"
 bc-rand = "^0.4.0"
 anyhow = "^1.0.0"
+bc-tags = "0.3.0"
 
 [features]
 default = ["signature", "encrypt", "compress", "known_value", "types"]

--- a/src/parse/leaf/mod.rs
+++ b/src/parse/leaf/mod.rs
@@ -152,6 +152,25 @@ pub(crate) fn parse_byte_string(
     }
 }
 
+pub(crate) fn parse_cbor(lexer: &mut logos::Lexer<Token>) -> Result<Pattern> {
+    let mut lookahead = lexer.clone();
+    match lookahead.next() {
+        Some(Ok(Token::ParenOpen)) => {
+            lexer.next();
+            let src = lexer.remainder();
+            let (pattern, consumed) = utils::parse_cbor_inner(src)?;
+            lexer.bump(consumed);
+            match lexer.next() {
+                Some(Ok(Token::ParenClose)) => Ok(pattern),
+                Some(Ok(t)) => Err(Error::UnexpectedToken(Box::new(t), lexer.span())),
+                Some(Err(e)) => Err(e),
+                None => Err(Error::ExpectedCloseParen(lexer.span())),
+            }
+        }
+        _ => Ok(Pattern::any_cbor()),
+    }
+}
+
 pub(crate) fn parse_number(lexer: &mut logos::Lexer<Token>) -> Result<Pattern> {
     let mut lookahead = lexer.clone();
     match lookahead.next() {

--- a/src/parse/meta/mod.rs
+++ b/src/parse/meta/mod.rs
@@ -85,6 +85,7 @@ fn parse_primary(lexer: &mut logos::Lexer<Token>) -> Result<Pattern> {
         Token::Tag => leaf::parse_tag(lexer),
         Token::Known => leaf::parse_known_value(lexer),
         Token::Leaf => Ok(Pattern::any_leaf()),
+        Token::Cbor => leaf::parse_cbor(lexer),
         Token::Map => leaf::parse_map(lexer),
         Token::None => Ok(Pattern::none()),
         Token::Null => leaf::parse_null(lexer),

--- a/tests/parse_tests.rs
+++ b/tests/parse_tests.rs
@@ -333,3 +333,41 @@ fn parse_known_value_patterns() {
     assert_eq!(p, Pattern::known_value_regex(regex));
     assert_eq!(p.to_string(), "KNOWN(/da.*/)");
 }
+
+#[test]
+fn parse_cbor_patterns() {
+    use bc_envelope::prelude::*;
+    use dcbor::{CBOR, Map};
+    use bc_tags::register_tags as register_old_tags;
+    bc_envelope::register_tags();
+    register_old_tags();
+
+    let p = parse_pattern("CBOR").unwrap();
+    assert_eq!(p, Pattern::any_cbor());
+    assert_eq!(p.to_string(), "CBOR");
+
+    let p = parse_pattern("CBOR(true)").unwrap();
+    assert_eq!(p, Pattern::cbor(true));
+    assert_eq!(p.to_string(), "CBOR(true)");
+
+    let p = parse_pattern("CBOR([1, 2, 3])").unwrap();
+    assert_eq!(p, Pattern::cbor(vec![1, 2, 3]));
+    assert_eq!(p.to_string(), "CBOR([1, 2, 3])");
+
+    let p = parse_pattern("CBOR({\"a\": 1})").unwrap();
+    let mut map = Map::new();
+    map.insert("a", 1);
+    assert_eq!(p, Pattern::cbor(map.clone()));
+    assert_eq!(p.to_string(), "CBOR({\"a\": 1})");
+
+    let p = parse_pattern("CBOR(1(\"hi\"))").unwrap();
+    assert_eq!(p, Pattern::cbor(CBOR::to_tagged_value(1, "hi")));
+    assert_eq!(p.to_string(), "CBOR(1(\"hi\"))");
+
+    let date = dcbor::Date::from_ymd(2025, 5, 15);
+    let ur = date.ur_string();
+    let expr = format!("CBOR({})", ur);
+    let p = parse_pattern(&expr).unwrap();
+    assert_eq!(p, Pattern::cbor(date.clone()));
+    assert_eq!(p.to_string(), format!("CBOR({})", date.to_cbor().diagnostic_flat()));
+}


### PR DESCRIPTION
## Summary
- add `parse_cbor` leaf parser
- support dCBOR diagnostic notation via `dcbor-parse`
- integrate CBOR parsing with meta parser
- handle UR/date examples and diagnostic value conversion
- test various CBOR pattern forms

## Testing
- `cargo test --test parse_tests -- --nocapture`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68526ce476288325b6dcb2fe4eab7a52