### PR TITLE
Implement node, wrapped and subject parsers

### DIFF
--- a/src/parse/meta/mod.rs
+++ b/src/parse/meta/mod.rs
@@ -1,6 +1,6 @@
 // Parsers for meta-pattern operators
 
-use super::{Token, leaf};
+use super::{leaf, structure, Token};
 use crate::{Error, Pattern, Result};
 
 pub(crate) fn parse_or(lexer: &mut logos::Lexer<Token>) -> Result<Pattern> {
@@ -25,9 +25,7 @@ pub(crate) fn parse_or(lexer: &mut logos::Lexer<Token>) -> Result<Pattern> {
     }
 }
 
-pub(crate) fn parse_sequence(
-    lexer: &mut logos::Lexer<Token>,
-) -> Result<Pattern> {
+pub(crate) fn parse_sequence(lexer: &mut logos::Lexer<Token>) -> Result<Pattern> {
     let mut patterns = vec![parse_and(lexer)?];
 
     loop {
@@ -87,6 +85,9 @@ fn parse_primary(lexer: &mut logos::Lexer<Token>) -> Result<Pattern> {
         Token::Leaf => Ok(Pattern::any_leaf()),
         Token::Cbor => leaf::parse_cbor(lexer),
         Token::Map => leaf::parse_map(lexer),
+        Token::Node => structure::parse_node(lexer),
+        Token::Wrapped => structure::parse_wrapped(lexer),
+        Token::Subject => structure::parse_subject(lexer),
         Token::None => Ok(Pattern::none()),
         Token::Null => leaf::parse_null(lexer),
         Token::Number => leaf::parse_number(lexer),

--- a/src/parse/structure/mod.rs
+++ b/src/parse/structure/mod.rs
@@ -1,3 +1,54 @@
 // Parsers for structure-level pattern syntax
 
-// Currently unused but reserved for future expansion.
+use super::{meta, Token};
+use crate::{Error, Pattern, Result};
+
+pub(crate) fn parse_node(lexer: &mut logos::Lexer<Token>) -> Result<Pattern> {
+    let mut lookahead = lexer.clone();
+    match lookahead.next() {
+        Some(Ok(Token::ParenOpen)) => {
+            lexer.next();
+            match lexer.next() {
+                Some(Ok(Token::Range(res))) => {
+                    let range = res?;
+                    let pat = if let Some(max) = range.max() {
+                        Pattern::node_with_assertions_range(range.min()..=max)
+                    } else {
+                        Pattern::node_with_assertions_range(range.min()..)
+                    };
+                    match lexer.next() {
+                        Some(Ok(Token::ParenClose)) => Ok(pat),
+                        Some(Ok(t)) => Err(Error::UnexpectedToken(Box::new(t), lexer.span())),
+                        Some(Err(e)) => Err(e),
+                        None => Err(Error::ExpectedCloseParen(lexer.span())),
+                    }
+                }
+                Some(Ok(t)) => Err(Error::UnexpectedToken(Box::new(t), lexer.span())),
+                Some(Err(e)) => Err(e),
+                None => Err(Error::UnexpectedEndOfInput),
+            }
+        }
+        _ => Ok(Pattern::any_node()),
+    }
+}
+
+pub(crate) fn parse_wrapped(_lexer: &mut logos::Lexer<Token>) -> Result<Pattern> {
+    Ok(Pattern::wrapped())
+}
+
+pub(crate) fn parse_subject(lexer: &mut logos::Lexer<Token>) -> Result<Pattern> {
+    let mut lookahead = lexer.clone();
+    match lookahead.next() {
+        Some(Ok(Token::ParenOpen)) => {
+            lexer.next();
+            let pattern = meta::parse_or(lexer)?;
+            match lexer.next() {
+                Some(Ok(Token::ParenClose)) => Ok(Pattern::subject(pattern)),
+                Some(Ok(t)) => Err(Error::UnexpectedToken(Box::new(t), lexer.span())),
+                Some(Err(e)) => Err(e),
+                None => Err(Error::ExpectedCloseParen(lexer.span())),
+            }
+        }
+        _ => Ok(Pattern::any_subject()),
+    }
+}

--- a/tests/parse_tests.rs
+++ b/tests/parse_tests.rs
@@ -1,4 +1,4 @@
-use bc_envelope_pattern::{Pattern, parse_pattern};
+use bc_envelope_pattern::{parse_pattern, Pattern};
 use known_values::KnownValue;
 
 #[test]
@@ -337,8 +337,8 @@ fn parse_known_value_patterns() {
 #[test]
 fn parse_cbor_patterns() {
     use bc_envelope::prelude::*;
-    use dcbor::{CBOR, Map};
     use bc_tags::register_tags as register_old_tags;
+    use dcbor::{Map, CBOR};
     bc_envelope::register_tags();
     register_old_tags();
 
@@ -369,5 +369,37 @@ fn parse_cbor_patterns() {
     let expr = format!("CBOR({})", ur);
     let p = parse_pattern(&expr).unwrap();
     assert_eq!(p, Pattern::cbor(date.clone()));
-    assert_eq!(p.to_string(), format!("CBOR({})", date.to_cbor().diagnostic_flat()));
+    assert_eq!(
+        p.to_string(),
+        format!("CBOR({})", date.to_cbor().diagnostic_flat())
+    );
+}
+
+#[test]
+fn parse_node_patterns() {
+    let p = parse_pattern("NODE").unwrap();
+    assert_eq!(p, Pattern::any_node());
+    assert_eq!(p.to_string(), "NODE");
+
+    let p = parse_pattern("NODE({1,3})").unwrap();
+    assert_eq!(p, Pattern::node_with_assertions_range(1..=3));
+    assert_eq!(p.to_string(), "NODE({1,3})");
+}
+
+#[test]
+fn parse_wrapped_pattern() {
+    let p = parse_pattern("WRAPPED").unwrap();
+    assert_eq!(p, Pattern::wrapped());
+    assert_eq!(p.to_string(), "WRAPPED");
+}
+
+#[test]
+fn parse_subject_patterns() {
+    let p = parse_pattern("SUBJECT").unwrap();
+    assert_eq!(p, Pattern::any_subject());
+    assert_eq!(p.to_string(), "SUBJECT");
+
+    let p = parse_pattern("SUBJECT(TEXT(\"hi\"))").unwrap();
+    assert_eq!(p, Pattern::subject(Pattern::text("hi")));
+    assert_eq!(p.to_string(), "SUBJECT(TEXT(\"hi\"))");
 }


### PR DESCRIPTION
## Summary
- implement `NODE`, `SUBJECT`, and `WRAPPED` structure pattern parsers
- wire the new parsers into meta parsing logic
- test parsing of node, wrapped, and subject patterns

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6852788cc18c8325aef26889cf066b8b