### PR TITLE
Add Digest pattern parsing

### DIFF
--- a/src/parse/meta/mod.rs
+++ b/src/parse/meta/mod.rs
@@ -89,6 +89,7 @@ fn parse_primary(lexer: &mut logos::Lexer<Token>) -> Result<Pattern> {
         Token::Assertion => structure::parse_assertion(lexer),
         Token::AssertionPred => structure::parse_assertion_pred(lexer),
         Token::AssertionObj => structure::parse_assertion_obj(lexer),
+        Token::Digest => structure::parse_digest(lexer),
         Token::Obj => structure::parse_object(lexer),
         Token::Obscured => structure::parse_obscured(lexer),
         Token::Elided => structure::parse_elided(lexer),

--- a/src/parse/structure/mod.rs
+++ b/src/parse/structure/mod.rs
@@ -2,6 +2,8 @@
 
 use super::{meta, Token};
 use crate::{Error, Pattern, Result};
+use bc_components::Digest;
+use bc_envelope::prelude::URDecodable;
 
 pub(crate) fn parse_node(lexer: &mut logos::Lexer<Token>) -> Result<Pattern> {
     let mut lookahead = lexer.clone();
@@ -109,6 +111,66 @@ pub(crate) fn parse_object(lexer: &mut logos::Lexer<Token>) -> Result<Pattern> {
             }
         }
         _ => Ok(Pattern::any_object()),
+    }
+}
+
+pub(crate) fn parse_digest(lexer: &mut logos::Lexer<Token>) -> Result<Pattern> {
+    match lexer.next() {
+        Some(Ok(Token::ParenOpen)) => {
+            let src = lexer.remainder();
+            let (pattern, consumed) = parse_digest_inner(src)?;
+            lexer.bump(consumed);
+            match lexer.next() {
+                Some(Ok(Token::ParenClose)) => Ok(pattern),
+                Some(Ok(t)) => Err(Error::UnexpectedToken(Box::new(t), lexer.span())),
+                Some(Err(e)) => Err(e),
+                None => Err(Error::ExpectedCloseParen(lexer.span())),
+            }
+        }
+        Some(Ok(t)) => Err(Error::UnexpectedToken(Box::new(t), lexer.span())),
+        Some(Err(e)) => Err(e),
+        None => Err(Error::UnexpectedEndOfInput),
+    }
+}
+
+fn parse_digest_inner(src: &str) -> Result<(Pattern, usize)> {
+    let mut pos = 0;
+    super::utils::skip_ws(src, &mut pos);
+    if src[pos..].starts_with("ur:") {
+        let start = pos;
+        while let Some(ch) = src[pos..].chars().next() {
+            if ch == ')' {
+                break;
+            }
+            pos += ch.len_utf8();
+        }
+        let ur = src[start..pos].trim_end();
+        let digest = Digest::from_ur_string(ur)
+            .map_err(|_| Error::InvalidUr(ur.to_string(), pos..pos))?;
+        super::utils::skip_ws(src, &mut pos);
+        Ok((Pattern::digest(digest), pos))
+    } else {
+        let start = pos;
+        while let Some(ch) = src[pos..].chars().next() {
+            if ch.is_ascii_hexdigit() {
+                pos += ch.len_utf8();
+            } else {
+                break;
+            }
+        }
+        if start == pos {
+            return Err(Error::InvalidHexString(pos..pos));
+        }
+        let hex_str = &src[start..pos];
+        if hex_str.len() % 2 != 0 {
+            return Err(Error::InvalidHexString(pos..pos));
+        }
+        let bytes = hex::decode(hex_str).map_err(|_| Error::InvalidHexString(pos..pos))?;
+        if bytes.len() > Digest::DIGEST_SIZE {
+            return Err(Error::InvalidHexString(pos..pos));
+        }
+        super::utils::skip_ws(src, &mut pos);
+        Ok((Pattern::digest_prefix(bytes), pos))
     }
 }
 


### PR DESCRIPTION
## Summary
- support `DIGEST` patterns in parser
- allow hex prefix and UR string digests
- test digest pattern parsing

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685282cc16bc8325aaff7e8b40a86cda