### PR TITLE
Implement Not pattern parser

### DIFF
--- a/src/parse/meta/mod.rs
+++ b/src/parse/meta/mod.rs
@@ -26,14 +26,14 @@ pub(crate) fn parse_or(lexer: &mut logos::Lexer<Token>) -> Result<Pattern> {
 }
 
 pub(crate) fn parse_sequence(lexer: &mut logos::Lexer<Token>) -> Result<Pattern> {
-    let mut patterns = vec![parse_and(lexer)?];
+    let mut patterns = vec![parse_not(lexer)?];
 
     loop {
         let mut lookahead = lexer.clone();
         match lookahead.next() {
             Some(Ok(Token::Sequence)) => {
                 lexer.next();
-                patterns.push(parse_and(lexer)?);
+                patterns.push(parse_not(lexer)?);
             }
             _ => break,
         }
@@ -43,6 +43,18 @@ pub(crate) fn parse_sequence(lexer: &mut logos::Lexer<Token>) -> Result<Pattern>
         Ok(patterns.remove(0))
     } else {
         Ok(Pattern::sequence(patterns))
+    }
+}
+
+pub(crate) fn parse_not(lexer: &mut logos::Lexer<Token>) -> Result<Pattern> {
+    let mut lookahead = lexer.clone();
+    match lookahead.next() {
+        Some(Ok(Token::Not)) => {
+            lexer.next();
+            let pat = parse_not(lexer)?;
+            Ok(Pattern::not_matching(pat))
+        }
+        _ => parse_and(lexer),
     }
 }
 

--- a/tests/parse_tests.rs
+++ b/tests/parse_tests.rs
@@ -1,6 +1,6 @@
-use dcbor::Date;
 use bc_envelope::prelude::*;
-use bc_envelope_pattern::{Pattern, parse_pattern};
+use bc_envelope_pattern::{parse_pattern, Pattern};
+use dcbor::Date;
 use known_values::KnownValue;
 
 #[test]
@@ -434,7 +434,10 @@ fn parse_assert_patterns() {
 
     let spaced = "ASSERTPRED ( TEXT(\"hi\") )";
     let p_spaced = parse_pattern(spaced).unwrap();
-    assert_eq!(p_spaced, Pattern::assertion_with_predicate(Pattern::text("hi")));
+    assert_eq!(
+        p_spaced,
+        Pattern::assertion_with_predicate(Pattern::text("hi"))
+    );
     assert_eq!(p_spaced.to_string(), "ASSERTPRED(TEXT(\"hi\"))");
 
     let p = parse_pattern("ASSERTOBJ(NUMBER(1))").unwrap();
@@ -491,4 +494,17 @@ fn parse_obscured_patterns() {
     let p = parse_pattern("COMPRESSED").unwrap();
     assert_eq!(p, Pattern::compressed());
     assert_eq!(p.to_string(), "COMPRESSED");
+}
+
+#[test]
+fn parse_not_patterns() {
+    let p = parse_pattern("!TEXT(\"hi\")").unwrap();
+    assert_eq!(p, Pattern::not_matching(Pattern::text("hi")));
+    assert_eq!(p.to_string(), "!TEXT(\"hi\")");
+
+    let expr = "!ANY & NONE";
+    let p = parse_pattern(expr).unwrap();
+    let expected = Pattern::not_matching(Pattern::and(vec![Pattern::any(), Pattern::none()]));
+    assert_eq!(p, expected);
+    assert_eq!(p.to_string(), "!ANY&NONE");
 }


### PR DESCRIPTION
## Summary
- implement `parse_not` for `!` patterns
- use `parse_not` in sequence parser
- add parsing tests for NOT to verify precedence

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6852836bfe148325b758ff120352db9e