### PR TITLE
Implement CapturePattern paths

### DIFF
--- a/src/pattern/matcher.rs
+++ b/src/pattern/matcher.rs
@@ -1,12 +1,22 @@
 use bc_envelope::Envelope;
+use std::collections::HashMap;
 
 use crate::pattern::{Pattern, vm::Instr};
 
 pub type Path = Vec<Envelope>;
 
 pub trait Matcher: std::fmt::Debug + std::fmt::Display + Clone {
-    fn paths(&self, _envelope: &Envelope) -> Vec<Path> {
-        unimplemented!("Matcher::paths not implemented for {:?}", self)
+    /// Return all matching paths along with any named captures.
+    fn paths_with_captures(
+        &self,
+        _envelope: &Envelope,
+    ) -> (Vec<Path>, HashMap<String, Path>) {
+        unimplemented!("Matcher::paths_with_captures not implemented for {:?}", self)
+    }
+
+    /// Return only the matching paths, discarding any captures.
+    fn paths(&self, envelope: &Envelope) -> Vec<Path> {
+        self.paths_with_captures(envelope).0
     }
 
     fn matches(&self, envelope: &Envelope) -> bool {

--- a/src/pattern/meta/capture_pattern.rs
+++ b/src/pattern/meta/capture_pattern.rs
@@ -24,15 +24,30 @@ impl CapturePattern {
     }
 
     /// Returns the name of the capture.
-    pub fn name(&self) -> &str { &self.name }
+    pub fn name(&self) -> &str {
+        &self.name
+    }
 
     /// Returns the inner pattern.
-    pub fn pattern(&self) -> &Pattern { &self.pattern }
+    pub fn pattern(&self) -> &Pattern {
+        &self.pattern
+    }
 }
 
 impl Matcher for CapturePattern {
-    fn paths(&self, _envelope: &Envelope) -> Vec<Path> {
-        todo!();
+    fn paths(&self, envelope: &Envelope) -> Vec<Path> {
+        self.paths_with_captures(envelope).0
+    }
+
+    fn paths_with_captures(
+        &self,
+        envelope: &Envelope,
+    ) -> (Vec<Path>, std::collections::HashMap<String, Path>) {
+        let (paths, mut caps) = self.pattern.paths_with_captures(envelope);
+        if let Some(p) = paths.first() {
+            caps.insert(self.name.clone(), p.clone());
+        }
+        (paths, caps)
     }
 
     fn compile(&self, code: &mut Vec<Instr>, lits: &mut Vec<Pattern>) {

--- a/tests/pattern_tests_meta.rs
+++ b/tests/pattern_tests_meta.rs
@@ -716,3 +716,20 @@ fn test_not_pattern_with_search() {
         }
     }
 }
+
+#[test]
+fn test_capture_pattern() {
+    let envelope = Envelope::new(42);
+
+    let inner = Pattern::number(42);
+    let capture = Pattern::capture("num", inner.clone());
+
+    assert_eq!(format!("{}", capture), "(NUMBER(42))");
+    assert!(capture.matches(&envelope));
+
+    let inner_paths = inner.paths(&envelope);
+    let (capture_paths, captures) = capture.paths_with_captures(&envelope);
+    assert!(capture_paths.iter().any(|p| *p == inner_paths[0]));
+    assert!(captures.contains_key("num"));
+    assert_eq!(captures.get("num").unwrap(), &inner_paths[0]);
+}


### PR DESCRIPTION
## Summary
- implement CapturePattern::paths_with_captures to return named captures
- add Matcher::paths_with_captures and delegate `paths()` to it
- support capture collection via Pattern helper methods
- test capture paths_with_captures

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_685296057c2883258bcc50bbcb55d950