### PR TITLE
Support multiple captures

### DIFF
--- a/src/pattern/matcher.rs
+++ b/src/pattern/matcher.rs
@@ -11,7 +11,7 @@ pub trait Matcher: std::fmt::Debug + std::fmt::Display + Clone {
     fn paths_with_captures(
         &self,
         _envelope: &Envelope,
-    ) -> (Vec<Path>, HashMap<String, Path>) {
+    ) -> (Vec<Path>, HashMap<String, Vec<Path>>) {
         unimplemented!(
             "Matcher::paths_with_captures not implemented for {:?}",
             self

--- a/src/pattern/meta/capture_pattern.rs
+++ b/src/pattern/meta/capture_pattern.rs
@@ -38,10 +38,12 @@ impl Matcher for CapturePattern {
     fn paths_with_captures(
         &self,
         envelope: &Envelope,
-    ) -> (Vec<Path>, std::collections::HashMap<String, Path>) {
+    ) -> (Vec<Path>, std::collections::HashMap<String, Vec<Path>>) {
         let (paths, mut caps) = self.pattern.paths_with_captures(envelope);
-        if let Some(p) = paths.first() {
-            caps.insert(self.name.clone(), p.clone());
+        if !paths.is_empty() {
+            caps.entry(self.name.clone())
+                .or_default()
+                .extend(paths.clone());
         }
         (paths, caps)
     }

--- a/src/pattern/pattern_impl.rs
+++ b/src/pattern/pattern_impl.rs
@@ -109,7 +109,7 @@ impl Matcher for Pattern {
     fn paths_with_captures(
         &self,
         env: &Envelope,
-    ) -> (Vec<Path>, HashMap<String, Path>) {
+    ) -> (Vec<Path>, HashMap<String, Vec<Path>>) {
         let paths = self.vm_paths(env);
         let mut captures = HashMap::new();
         self.collect_captures(env, &mut captures);
@@ -648,7 +648,7 @@ impl Pattern {
     fn collect_captures(
         &self,
         env: &Envelope,
-        map: &mut HashMap<String, Path>,
+        map: &mut HashMap<String, Vec<Path>>,
     ) {
         match self {
             Pattern::Leaf(_) | Pattern::Structure(_) => {}
@@ -661,13 +661,15 @@ impl MetaPattern {
     fn collect_captures(
         &self,
         env: &Envelope,
-        map: &mut HashMap<String, Path>,
+        map: &mut HashMap<String, Vec<Path>>,
     ) {
         match self {
             MetaPattern::Capture(cap) => {
                 let paths = cap.pattern().vm_paths(env);
-                if let Some(p) = paths.first() {
-                    map.insert(cap.name().to_string(), p.clone());
+                if !paths.is_empty() {
+                    map.entry(cap.name().to_string())
+                        .or_default()
+                        .extend(paths.clone());
                 }
                 cap.pattern().collect_captures(env, map);
             }

--- a/tests/pattern_tests_meta.rs
+++ b/tests/pattern_tests_meta.rs
@@ -731,5 +731,19 @@ fn test_capture_pattern() {
     let (capture_paths, captures) = capture.paths_with_captures(&envelope);
     assert!(capture_paths.iter().any(|p| *p == inner_paths[0]));
     assert!(captures.contains_key("num"));
-    assert_eq!(captures.get("num").unwrap(), &inner_paths[0]);
+    assert!(captures.get("num").unwrap().contains(&inner_paths[0]));
+}
+
+#[test]
+fn test_capture_multiple_matches() {
+    let envelope = Envelope::new(42);
+
+    let pattern = Pattern::or(vec![
+        Pattern::capture("num", Pattern::number(42)),
+        Pattern::capture("num", Pattern::number_greater_than(40)),
+    ]);
+
+    let (_paths, captures) = pattern.paths_with_captures(&envelope);
+    let nums = captures.get("num").unwrap();
+    assert_eq!(nums.len(), 2);
 }


### PR DESCRIPTION
## Summary
- allow capture patterns to return all matched paths
- adjust matcher trait to expose all captures as vectors
- test for multiple capture results

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6852fc307d588325bbdee7c3348419ce