### PR TITLE
Implement capture pattern parsing

### DIFF
--- a/src/parse/meta/capture_parser.rs
+++ b/src/parse/meta/capture_parser.rs
@@ -1,0 +1,24 @@
+use super::{super::Token, or_parser::parse_or};
+use crate::{Error, Pattern, Result};
+
+pub(crate) fn parse_capture(
+    lexer: &mut logos::Lexer<Token>,
+    name: String,
+) -> Result<Pattern> {
+    match lexer.next() {
+        Some(Ok(Token::ParenOpen)) => {
+            let pat = parse_or(lexer)?;
+            match lexer.next() {
+                Some(Ok(Token::ParenClose)) => Ok(Pattern::capture(name, pat)),
+                Some(Ok(t)) => {
+                    Err(Error::UnexpectedToken(Box::new(t), lexer.span()))
+                }
+                Some(Err(e)) => Err(e),
+                None => Err(Error::ExpectedCloseParen(lexer.span())),
+            }
+        }
+        Some(Ok(t)) => Err(Error::UnexpectedToken(Box::new(t), lexer.span())),
+        Some(Err(e)) => Err(e),
+        None => Err(Error::UnexpectedEndOfInput),
+    }
+}

--- a/src/parse/meta/mod.rs
+++ b/src/parse/meta/mod.rs
@@ -1,6 +1,7 @@
 // Parsers for meta-pattern operators
 
 mod and_parser;
+mod capture_parser;
 mod group_parser;
 mod not_parser;
 mod or_parser;
@@ -8,4 +9,5 @@ mod primary_parser;
 mod search_parser;
 mod sequence_parser;
 
+pub(crate) use capture_parser::parse_capture;
 pub(crate) use or_parser::parse_or;

--- a/src/parse/meta/primary_parser.rs
+++ b/src/parse/meta/primary_parser.rs
@@ -1,5 +1,6 @@
 use super::{
     super::{Token, leaf, structure},
+    capture_parser::parse_capture,
     group_parser::parse_group,
     search_parser::parse_search,
 };
@@ -26,6 +27,7 @@ pub(crate) fn parse_primary(
         Token::Cbor => leaf::parse_cbor(lexer),
         Token::Map => leaf::parse_map(lexer),
         Token::ParenOpen => parse_group(lexer),
+        Token::GroupName(name) => parse_capture(lexer, name),
         Token::Search => parse_search(lexer),
         Token::Node => structure::parse_node(lexer),
         Token::Assertion => structure::parse_assertion(lexer),

--- a/tests/parse_tests.rs
+++ b/tests/parse_tests.rs
@@ -569,3 +569,16 @@ fn parse_repeat_patterns() {
     );
     assert_eq!(p.to_string(), "(NUMBER){2,4}+");
 }
+
+#[test]
+fn parse_capture_patterns() {
+    let src = "@name(NUMBER(1))";
+    let p = parse_pattern(src).unwrap();
+    assert_eq!(p, Pattern::capture("name", Pattern::number(1)));
+    assert_eq!(p.to_string(), src);
+
+    let spaced = "@name ( NUMBER ( 1 ) )";
+    let p_spaced = parse_pattern(spaced).unwrap();
+    assert_eq!(p_spaced, Pattern::capture("name", Pattern::number(1)));
+    assert_eq!(p_spaced.to_string(), src);
+}


### PR DESCRIPTION
## Summary
- implement `parse_capture` for @name(...) patterns
- export `parse_capture` in parse meta module
- call `parse_capture` from the primary parser
- test capture parsing in `parse_pattern`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68530ca9c14c8325aca9cf5cea51d99d