### PR TITLE
Implement capture tracking in VM

### DIFF
--- a/src/pattern/leaf/array_pattern.rs
+++ b/src/pattern/leaf/array_pattern.rs
@@ -45,11 +45,17 @@ impl Matcher for ArrayPattern {
         }
     }
 
-    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+    fn compile(
+        &self,
+        code: &mut Vec<Instr>,
+        literals: &mut Vec<Pattern>,
+        captures: &mut Vec<String>,
+    ) {
         compile_as_atomic(
             &Pattern::Leaf(LeafPattern::Array(self.clone())),
             code,
             literals,
+            captures,
         );
     }
 }

--- a/src/pattern/leaf/bool_pattern.rs
+++ b/src/pattern/leaf/bool_pattern.rs
@@ -40,11 +40,17 @@ impl Matcher for BoolPattern {
         }
     }
 
-    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+    fn compile(
+        &self,
+        code: &mut Vec<Instr>,
+        literals: &mut Vec<Pattern>,
+        captures: &mut Vec<String>,
+    ) {
         compile_as_atomic(
             &Pattern::Leaf(LeafPattern::Bool(self.clone())),
             code,
             literals,
+            captures,
         );
     }
 }

--- a/src/pattern/leaf/byte_string_pattern.rs
+++ b/src/pattern/leaf/byte_string_pattern.rs
@@ -93,11 +93,17 @@ impl Matcher for ByteStringPattern {
         }
     }
 
-    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+    fn compile(
+        &self,
+        code: &mut Vec<Instr>,
+        literals: &mut Vec<Pattern>,
+        captures: &mut Vec<String>,
+    ) {
         compile_as_atomic(
             &Pattern::Leaf(LeafPattern::ByteString(self.clone())),
             code,
             literals,
+            captures,
         );
     }
 }

--- a/src/pattern/leaf/cbor_pattern.rs
+++ b/src/pattern/leaf/cbor_pattern.rs
@@ -63,11 +63,17 @@ impl Matcher for CBORPattern {
         }
     }
 
-    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+    fn compile(
+        &self,
+        code: &mut Vec<Instr>,
+        literals: &mut Vec<Pattern>,
+        captures: &mut Vec<String>,
+    ) {
         compile_as_atomic(
             &Pattern::Leaf(LeafPattern::Cbor(self.clone())),
             code,
             literals,
+            captures,
         );
     }
 }

--- a/src/pattern/leaf/date_pattern.rs
+++ b/src/pattern/leaf/date_pattern.rs
@@ -189,11 +189,17 @@ impl Matcher for DatePattern {
         }
     }
 
-    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+    fn compile(
+        &self,
+        code: &mut Vec<Instr>,
+        literals: &mut Vec<Pattern>,
+        captures: &mut Vec<String>,
+    ) {
         compile_as_atomic(
             &Pattern::Leaf(LeafPattern::Date(self.clone())),
             code,
             literals,
+            captures,
         );
     }
 }

--- a/src/pattern/leaf/known_value_pattern.rs
+++ b/src/pattern/leaf/known_value_pattern.rs
@@ -128,11 +128,17 @@ impl Matcher for KnownValuePattern {
         }
     }
 
-    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+    fn compile(
+        &self,
+        code: &mut Vec<Instr>,
+        literals: &mut Vec<Pattern>,
+        captures: &mut Vec<String>,
+    ) {
         compile_as_atomic(
             &Pattern::Leaf(LeafPattern::KnownValue(self.clone())),
             code,
             literals,
+            captures,
         );
     }
 }

--- a/src/pattern/leaf/leaf_pattern.rs
+++ b/src/pattern/leaf/leaf_pattern.rs
@@ -63,47 +63,53 @@ impl Matcher for LeafPattern {
         }
     }
 
-    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+    fn compile(
+        &self,
+        code: &mut Vec<Instr>,
+        literals: &mut Vec<Pattern>,
+        captures: &mut Vec<String>,
+    ) {
         match self {
             LeafPattern::Any => {
                 compile_as_atomic(
                     &Pattern::Leaf(LeafPattern::Any),
                     code,
                     literals,
+                    captures,
                 );
             }
             LeafPattern::Cbor(pattern) => {
-                pattern.compile(code, literals);
+                pattern.compile(code, literals, captures);
             }
             LeafPattern::Number(pattern) => {
-                pattern.compile(code, literals);
+                pattern.compile(code, literals, captures);
             }
             LeafPattern::Text(pattern) => {
-                pattern.compile(code, literals);
+                pattern.compile(code, literals, captures);
             }
             LeafPattern::ByteString(pattern) => {
-                pattern.compile(code, literals);
+                pattern.compile(code, literals, captures);
             }
             LeafPattern::Tag(pattern) => {
-                pattern.compile(code, literals);
+                pattern.compile(code, literals, captures);
             }
             LeafPattern::Array(pattern) => {
-                pattern.compile(code, literals);
+                pattern.compile(code, literals, captures);
             }
             LeafPattern::Map(pattern) => {
-                pattern.compile(code, literals);
+                pattern.compile(code, literals, captures);
             }
             LeafPattern::Bool(pattern) => {
-                pattern.compile(code, literals);
+                pattern.compile(code, literals, captures);
             }
             LeafPattern::Null(pattern) => {
-                pattern.compile(code, literals);
+                pattern.compile(code, literals, captures);
             }
             LeafPattern::Date(pattern) => {
-                pattern.compile(code, literals);
+                pattern.compile(code, literals, captures);
             }
             LeafPattern::KnownValue(pattern) => {
-                pattern.compile(code, literals);
+                pattern.compile(code, literals, captures);
             }
         }
     }

--- a/src/pattern/leaf/map_pattern.rs
+++ b/src/pattern/leaf/map_pattern.rs
@@ -45,11 +45,17 @@ impl Matcher for MapPattern {
         }
     }
 
-    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+    fn compile(
+        &self,
+        code: &mut Vec<Instr>,
+        literals: &mut Vec<Pattern>,
+        captures: &mut Vec<String>,
+    ) {
         compile_as_atomic(
             &Pattern::Leaf(LeafPattern::Map(self.clone())),
             code,
             literals,
+            captures,
         );
     }
 }

--- a/src/pattern/leaf/null_pattern.rs
+++ b/src/pattern/leaf/null_pattern.rs
@@ -27,11 +27,17 @@ impl Matcher for NullPattern {
         }
     }
 
-    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+    fn compile(
+        &self,
+        code: &mut Vec<Instr>,
+        literals: &mut Vec<Pattern>,
+        captures: &mut Vec<String>,
+    ) {
         compile_as_atomic(
             &Pattern::Leaf(LeafPattern::Null(self.clone())),
             code,
             literals,
+            captures,
         );
     }
 }

--- a/src/pattern/leaf/number_pattern.rs
+++ b/src/pattern/leaf/number_pattern.rs
@@ -184,7 +184,12 @@ impl Matcher for NumberPattern {
         }
     }
 
-    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+    fn compile(
+        &self,
+        code: &mut Vec<Instr>,
+        literals: &mut Vec<Pattern>,
+        captures: &mut Vec<String>,
+    ) {
         // A NumberPattern is a *leaf* predicate; it never changes
         // the current envelope pointer, so the default atomic helper
         // is perfect.  We must wrap `self` back into the outer
@@ -193,6 +198,7 @@ impl Matcher for NumberPattern {
             &Pattern::Leaf(LeafPattern::Number(self.clone())),
             code,
             literals,
+            captures,
         );
     }
 }

--- a/src/pattern/leaf/tagged_pattern.rs
+++ b/src/pattern/leaf/tagged_pattern.rs
@@ -136,11 +136,17 @@ impl Matcher for TaggedPattern {
         }
     }
 
-    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+    fn compile(
+        &self,
+        code: &mut Vec<Instr>,
+        literals: &mut Vec<Pattern>,
+        captures: &mut Vec<String>,
+    ) {
         compile_as_atomic(
             &Pattern::Leaf(LeafPattern::Tag(self.clone())),
             code,
             literals,
+            captures,
         );
     }
 }

--- a/src/pattern/leaf/text_pattern.rs
+++ b/src/pattern/leaf/text_pattern.rs
@@ -82,11 +82,17 @@ impl Matcher for TextPattern {
         }
     }
 
-    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+    fn compile(
+        &self,
+        code: &mut Vec<Instr>,
+        literals: &mut Vec<Pattern>,
+        captures: &mut Vec<String>,
+    ) {
         compile_as_atomic(
             &Pattern::Leaf(LeafPattern::Text(self.clone())),
             code,
             literals,
+            captures,
         );
     }
 }

--- a/src/pattern/matcher.rs
+++ b/src/pattern/matcher.rs
@@ -27,7 +27,12 @@ pub trait Matcher: std::fmt::Debug + std::fmt::Display + Clone {
         !self.paths(envelope).is_empty()
     }
 
-    fn compile(&self, _code: &mut Vec<Instr>, _literals: &mut Vec<Pattern>) {
+    fn compile(
+        &self,
+        _code: &mut Vec<Instr>,
+        _literals: &mut Vec<Pattern>,
+        _captures: &mut Vec<String>,
+    ) {
         unimplemented!("Matcher::compile not implemented for {:?}", self);
     }
 
@@ -44,6 +49,7 @@ pub fn compile_as_atomic(
     pat: &Pattern,
     code: &mut Vec<Instr>,
     lits: &mut Vec<Pattern>,
+    _captures: &mut Vec<String>,
 ) {
     let idx = lits.len();
     lits.push(pat.clone());

--- a/src/pattern/meta/and_pattern.rs
+++ b/src/pattern/meta/and_pattern.rs
@@ -27,10 +27,15 @@ impl Matcher for AndPattern {
     }
 
     /// Compile into byte-code (AND = all must match).
-    fn compile(&self, code: &mut Vec<Instr>, lits: &mut Vec<Pattern>) {
+    fn compile(
+        &self,
+        code: &mut Vec<Instr>,
+        lits: &mut Vec<Pattern>,
+        captures: &mut Vec<String>,
+    ) {
         // Each pattern must match at this position
         for pattern in self.patterns() {
-            pattern.compile(code, lits);
+            pattern.compile(code, lits, captures);
         }
     }
 

--- a/src/pattern/meta/any_pattern.rs
+++ b/src/pattern/meta/any_pattern.rs
@@ -23,11 +23,17 @@ impl Matcher for AnyPattern {
         vec![vec![envelope.clone()]]
     }
 
-    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+    fn compile(
+        &self,
+        code: &mut Vec<Instr>,
+        literals: &mut Vec<Pattern>,
+        captures: &mut Vec<String>,
+    ) {
         compile_as_atomic(
             &Pattern::Meta(MetaPattern::Any(self.clone())),
             code,
             literals,
+            captures,
         );
     }
 }

--- a/src/pattern/meta/capture_pattern.rs
+++ b/src/pattern/meta/capture_pattern.rs
@@ -48,10 +48,17 @@ impl Matcher for CapturePattern {
         (paths, caps)
     }
 
-    fn compile(&self, code: &mut Vec<Instr>, lits: &mut Vec<Pattern>) {
-        code.push(Instr::Save); // start
-        self.pattern.compile(code, lits);
-        code.push(Instr::Save); // end
+    fn compile(
+        &self,
+        code: &mut Vec<Instr>,
+        lits: &mut Vec<Pattern>,
+        captures: &mut Vec<String>,
+    ) {
+        let id = captures.len();
+        captures.push(self.name.clone());
+        code.push(Instr::CaptureStart(id));
+        self.pattern.compile(code, lits, captures);
+        code.push(Instr::CaptureEnd(id));
     }
 }
 

--- a/src/pattern/meta/meta_pattern.rs
+++ b/src/pattern/meta/meta_pattern.rs
@@ -51,17 +51,22 @@ impl Matcher for MetaPattern {
         }
     }
 
-    fn compile(&self, code: &mut Vec<Instr>, lits: &mut Vec<Pattern>) {
+    fn compile(
+        &self,
+        code: &mut Vec<Instr>,
+        lits: &mut Vec<Pattern>,
+        captures: &mut Vec<String>,
+    ) {
         match self {
-            MetaPattern::Any(pattern) => pattern.compile(code, lits),
-            MetaPattern::None(pattern) => pattern.compile(code, lits),
-            MetaPattern::And(pattern) => pattern.compile(code, lits),
-            MetaPattern::Or(pattern) => pattern.compile(code, lits),
-            MetaPattern::Not(pattern) => pattern.compile(code, lits),
-            MetaPattern::Search(pattern) => pattern.compile(code, lits),
-            MetaPattern::Sequence(pattern) => pattern.compile(code, lits),
-            MetaPattern::Group(pattern) => pattern.compile(code, lits),
-            MetaPattern::Capture(pattern) => pattern.compile(code, lits),
+            MetaPattern::Any(pattern) => pattern.compile(code, lits, captures),
+            MetaPattern::None(pattern) => pattern.compile(code, lits, captures),
+            MetaPattern::And(pattern) => pattern.compile(code, lits, captures),
+            MetaPattern::Or(pattern) => pattern.compile(code, lits, captures),
+            MetaPattern::Not(pattern) => pattern.compile(code, lits, captures),
+            MetaPattern::Search(pattern) => pattern.compile(code, lits, captures),
+            MetaPattern::Sequence(pattern) => pattern.compile(code, lits, captures),
+            MetaPattern::Group(pattern) => pattern.compile(code, lits, captures),
+            MetaPattern::Capture(pattern) => pattern.compile(code, lits, captures),
         }
     }
 

--- a/src/pattern/meta/none_pattern.rs
+++ b/src/pattern/meta/none_pattern.rs
@@ -23,11 +23,17 @@ impl Matcher for NonePattern {
         Vec::new()
     }
 
-    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+    fn compile(
+        &self,
+        code: &mut Vec<Instr>,
+        literals: &mut Vec<Pattern>,
+        captures: &mut Vec<String>,
+    ) {
         compile_as_atomic(
             &Pattern::Meta(MetaPattern::None(self.clone())),
             code,
             literals,
+            captures,
         );
     }
 }

--- a/src/pattern/meta/not_pattern.rs
+++ b/src/pattern/meta/not_pattern.rs
@@ -26,7 +26,12 @@ impl Matcher for NotPattern {
     }
 
     /// Compile into byte-code (NOT = negation of the inner pattern).
-    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+    fn compile(
+        &self,
+        code: &mut Vec<Instr>,
+        literals: &mut Vec<Pattern>,
+        _captures: &mut Vec<String>,
+    ) {
         // NOT = check that pattern doesn't match
         let idx = literals.len();
         literals.push(self.pattern().clone());

--- a/src/pattern/meta/or_pattern.rs
+++ b/src/pattern/meta/or_pattern.rs
@@ -27,7 +27,12 @@ impl Matcher for OrPattern {
     }
 
     /// Compile into byte-code (OR = any can match).
-    fn compile(&self, code: &mut Vec<Instr>, lits: &mut Vec<Pattern>) {
+    fn compile(
+        &self,
+        code: &mut Vec<Instr>,
+        lits: &mut Vec<Pattern>,
+        captures: &mut Vec<String>,
+    ) {
         if self.patterns().is_empty() {
             return;
         }
@@ -46,7 +51,7 @@ impl Matcher for OrPattern {
             let pattern_start = code.len();
 
             // Compile this pattern
-            pattern.compile(code, lits);
+            pattern.compile(code, lits, captures);
 
             // This pattern will jump to the end if it matches
             let jump_past_all = code.len();

--- a/src/pattern/meta/repeat_pattern.rs
+++ b/src/pattern/meta/repeat_pattern.rs
@@ -36,7 +36,12 @@ impl GroupPattern {
 
 impl Matcher for GroupPattern {
     /// Emit a high-level `Repeat` instruction for the VM.
-    fn compile(&self, code: &mut Vec<Instr>, lits: &mut Vec<Pattern>) {
+    fn compile(
+        &self,
+        code: &mut Vec<Instr>,
+        lits: &mut Vec<Pattern>,
+        _captures: &mut Vec<String>,
+    ) {
         let idx = lits.len();
         lits.push((*self.pattern).clone());
         code.push(Instr::Repeat { pat_idx: idx, quantifier: self.quantifier });

--- a/src/pattern/meta/search_pattern.rs
+++ b/src/pattern/meta/search_pattern.rs
@@ -59,7 +59,12 @@ impl Matcher for SearchPattern {
         result_paths.into_inner()
     }
 
-    fn compile(&self, code: &mut Vec<Instr>, lits: &mut Vec<Pattern>) {
+    fn compile(
+        &self,
+        code: &mut Vec<Instr>,
+        lits: &mut Vec<Pattern>,
+        _captures: &mut Vec<String>,
+    ) {
         let idx = lits.len();
         lits.push((*self.0).clone());
         code.push(Instr::Search { pat_idx: idx });

--- a/src/pattern/meta/sequence_pattern.rs
+++ b/src/pattern/meta/sequence_pattern.rs
@@ -56,15 +56,20 @@ impl Matcher for SequencePattern {
     }
 
     /// Compile into byte-code (sequential).
-    fn compile(&self, code: &mut Vec<Instr>, lits: &mut Vec<Pattern>) {
+    fn compile(
+        &self,
+        code: &mut Vec<Instr>,
+        lits: &mut Vec<Pattern>,
+        captures: &mut Vec<String>,
+    ) {
         // Compile the first pattern
-        self.first.compile(code, lits);
+        self.first.compile(code, lits, captures);
 
         if let Some(rest) = &self.rest {
             // Save the current path and switch to last envelope
             code.push(Instr::ExtendSequence);
             // Compile the rest of the sequence
-            rest.compile(code, lits);
+            rest.compile(code, lits, captures);
             // Combine the paths correctly
             code.push(Instr::CombineSequence);
         }

--- a/src/pattern/structure/assertions_pattern.rs
+++ b/src/pattern/structure/assertions_pattern.rs
@@ -58,7 +58,12 @@ impl Matcher for AssertionsPattern {
         result
     }
 
-    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+    fn compile(
+        &self,
+        code: &mut Vec<Instr>,
+        literals: &mut Vec<Pattern>,
+        _captures: &mut Vec<String>,
+    ) {
         let idx = literals.len();
         literals.push(Pattern::Structure(StructurePattern::Assertions(
             self.clone(),

--- a/src/pattern/structure/digest_pattern.rs
+++ b/src/pattern/structure/digest_pattern.rs
@@ -89,11 +89,17 @@ impl Matcher for DigestPattern {
         }
     }
 
-    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+    fn compile(
+        &self,
+        code: &mut Vec<Instr>,
+        literals: &mut Vec<Pattern>,
+        captures: &mut Vec<String>,
+    ) {
         compile_as_atomic(
             &Pattern::Structure(StructurePattern::Digest(self.clone())),
             code,
             literals,
+            captures,
         );
     }
 }

--- a/src/pattern/structure/node_pattern.rs
+++ b/src/pattern/structure/node_pattern.rs
@@ -50,11 +50,17 @@ impl Matcher for NodePattern {
         }
     }
 
-    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+    fn compile(
+        &self,
+        code: &mut Vec<Instr>,
+        literals: &mut Vec<Pattern>,
+        captures: &mut Vec<String>,
+    ) {
         compile_as_atomic(
             &Pattern::Structure(StructurePattern::Node(self.clone())),
             code,
             literals,
+            captures,
         );
     }
 }

--- a/src/pattern/structure/object_pattern.rs
+++ b/src/pattern/structure/object_pattern.rs
@@ -38,7 +38,12 @@ impl Matcher for ObjectPattern {
         }
     }
 
-    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+    fn compile(
+        &self,
+        code: &mut Vec<Instr>,
+        literals: &mut Vec<Pattern>,
+        _captures: &mut Vec<String>,
+    ) {
         let idx = literals.len();
         literals
             .push(Pattern::Structure(StructurePattern::Object(self.clone())));

--- a/src/pattern/structure/obscured_pattern.rs
+++ b/src/pattern/structure/obscured_pattern.rs
@@ -51,11 +51,17 @@ impl Matcher for ObscuredPattern {
         }
     }
 
-    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+    fn compile(
+        &self,
+        code: &mut Vec<Instr>,
+        literals: &mut Vec<Pattern>,
+        captures: &mut Vec<String>,
+    ) {
         compile_as_atomic(
             &Pattern::Structure(StructurePattern::Obscured(self.clone())),
             code,
             literals,
+            captures,
         );
     }
 }

--- a/src/pattern/structure/predicate_pattern.rs
+++ b/src/pattern/structure/predicate_pattern.rs
@@ -38,7 +38,12 @@ impl Matcher for PredicatePattern {
         }
     }
 
-    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+    fn compile(
+        &self,
+        code: &mut Vec<Instr>,
+        literals: &mut Vec<Pattern>,
+        _captures: &mut Vec<String>,
+    ) {
         let idx = literals.len();
         literals.push(Pattern::Structure(StructurePattern::Predicate(
             self.clone(),

--- a/src/pattern/structure/structure_pattern.rs
+++ b/src/pattern/structure/structure_pattern.rs
@@ -41,16 +41,21 @@ impl Matcher for StructurePattern {
         }
     }
 
-    fn compile(&self, code: &mut Vec<Instr>, lits: &mut Vec<Pattern>) {
+    fn compile(
+        &self,
+        code: &mut Vec<Instr>,
+        lits: &mut Vec<Pattern>,
+        captures: &mut Vec<String>,
+    ) {
         match self {
-            StructurePattern::Subject(s) => s.compile(code, lits),
-            StructurePattern::Assertions(s) => s.compile(code, lits),
-            StructurePattern::Wrapped(s) => s.compile(code, lits),
-            StructurePattern::Object(s) => s.compile(code, lits),
-            StructurePattern::Digest(s) => s.compile(code, lits),
-            StructurePattern::Node(s) => s.compile(code, lits),
-            StructurePattern::Obscured(s) => s.compile(code, lits),
-            StructurePattern::Predicate(s) => s.compile(code, lits),
+            StructurePattern::Subject(s) => s.compile(code, lits, captures),
+            StructurePattern::Assertions(s) => s.compile(code, lits, captures),
+            StructurePattern::Wrapped(s) => s.compile(code, lits, captures),
+            StructurePattern::Object(s) => s.compile(code, lits, captures),
+            StructurePattern::Digest(s) => s.compile(code, lits, captures),
+            StructurePattern::Node(s) => s.compile(code, lits, captures),
+            StructurePattern::Obscured(s) => s.compile(code, lits, captures),
+            StructurePattern::Predicate(s) => s.compile(code, lits, captures),
         }
     }
 

--- a/src/pattern/structure/subject_pattern.rs
+++ b/src/pattern/structure/subject_pattern.rs
@@ -33,7 +33,12 @@ impl Matcher for SubjectPattern {
         }
     }
 
-    fn compile(&self, code: &mut Vec<Instr>, literals: &mut Vec<Pattern>) {
+    fn compile(
+        &self,
+        code: &mut Vec<Instr>,
+        literals: &mut Vec<Pattern>,
+        captures: &mut Vec<String>,
+    ) {
         match self {
             SubjectPattern::Any => {
                 code.push(Instr::NavigateSubject);
@@ -47,7 +52,7 @@ impl Matcher for SubjectPattern {
                 // that any paths produced by `pattern` are appended to the
                 // subject path rather than replacing it.
                 code.push(Instr::ExtendSequence);
-                pattern.compile(code, literals);
+                pattern.compile(code, literals, captures);
                 code.push(Instr::CombineSequence);
             }
         }

--- a/src/pattern/structure/wrapped_pattern.rs
+++ b/src/pattern/structure/wrapped_pattern.rs
@@ -33,7 +33,12 @@ impl Matcher for WrappedPattern {
     }
 
     /// Emit predicate + descent so the VM makes progress.
-    fn compile(&self, code: &mut Vec<Instr>, lits: &mut Vec<Pattern>) {
+    fn compile(
+        &self,
+        code: &mut Vec<Instr>,
+        lits: &mut Vec<Pattern>,
+        _captures: &mut Vec<String>,
+    ) {
         // println!("Compiling WrappedPattern: {:?}", self);
         // 1) atomic predicate “is wrapped”
         let idx = lits.len();

--- a/tests/pattern_tests_meta.rs
+++ b/tests/pattern_tests_meta.rs
@@ -747,3 +747,31 @@ fn test_capture_multiple_matches() {
     let nums = captures.get("num").unwrap();
     assert_eq!(nums.len(), 2);
 }
+
+#[test]
+fn test_capture_in_and_failure() {
+    let envelope = Envelope::new(42);
+
+    let pattern = Pattern::and(vec![
+        Pattern::capture("num", Pattern::number(42)),
+        Pattern::bool(true),
+    ]);
+
+    let (paths, captures) = pattern.paths_with_captures(&envelope);
+    assert!(paths.is_empty());
+    assert!(captures.get("num").is_none());
+}
+
+#[test]
+fn test_capture_in_sequence_failure() {
+    let envelope = Envelope::new(42).add_assertion("an", "assertion");
+
+    let pattern = Pattern::sequence(vec![
+        Pattern::capture("num", Pattern::subject(Pattern::number(42))),
+        Pattern::bool(true),
+    ]);
+
+    let (paths, captures) = pattern.paths_with_captures(&envelope);
+    assert!(paths.is_empty());
+    assert!(captures.get("num").is_none());
+}


### PR DESCRIPTION
## Summary
- add capture start/end instructions and support capturing paths directly in the VM
- extend VM structures and return type to include capture maps
- update pattern compilation to assign capture IDs and emit new instructions
- remove old capture collection logic and update matcher implementations
- add regression tests for captures within composite patterns

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68530cb23d848325aab45a043a485ddc