### PR TITLE
Add capture parsing and matching tests

### DIFF
--- a/tests/capture_tests.rs
+++ b/tests/capture_tests.rs
@@ -1,0 +1,42 @@
+mod common;
+
+use bc_envelope::prelude::*;
+use bc_envelope_pattern::{parse_pattern, Matcher};
+
+#[test]
+fn capture_simple_number() {
+    let env = Envelope::new(42);
+    let pat = parse_pattern("@num(NUMBER(42))").unwrap();
+    let (paths, caps) = pat.paths_with_captures(&env);
+    assert_eq!(paths.len(), 1);
+    assert_eq!(caps.get("num").unwrap().len(), 1);
+    assert_eq!(pat.to_string(), "@num(NUMBER(42))");
+}
+
+#[test]
+fn capture_multiple_or() {
+    let env = Envelope::new(42);
+    let pat = parse_pattern("@num(NUMBER(42))|@num(NUMBER(>40))").unwrap();
+    let (_paths, caps) = pat.paths_with_captures(&env);
+    let nums = caps.get("num").unwrap();
+    assert_eq!(nums.len(), 2);
+}
+
+#[test]
+fn capture_nested_number() {
+    let env = Envelope::new(42);
+    let pat = parse_pattern("@outer(@inner(NUMBER(42)))").unwrap();
+    let (paths, caps) = pat.paths_with_captures(&env);
+    assert_eq!(paths.len(), 1);
+    assert!(caps.contains_key("outer"));
+    assert!(caps.contains_key("inner"));
+}
+
+#[test]
+fn capture_no_match() {
+    let env = Envelope::new(1);
+    let pat = parse_pattern("@n(NUMBER(2))").unwrap();
+    let (paths, caps) = pat.paths_with_captures(&env);
+    assert!(paths.is_empty());
+    assert!(caps.get("n").is_none());
+}

--- a/tests/parse_tests.rs
+++ b/tests/parse_tests.rs
@@ -582,3 +582,22 @@ fn parse_capture_patterns() {
     assert_eq!(p_spaced, Pattern::capture("name", Pattern::number(1)));
     assert_eq!(p_spaced.to_string(), src);
 }
+
+#[test]
+fn parse_nested_capture_patterns() {
+    let src = "@outer(@inner(TEXT(\"hi\")))";
+    let p = parse_pattern(src).unwrap();
+    assert_eq!(
+        p,
+        Pattern::capture("outer", Pattern::capture("inner", Pattern::text("hi")))
+    );
+    assert_eq!(p.to_string(), src);
+}
+
+#[test]
+fn parse_capture_name_variants() {
+    let src = "@cap_1(NUMBER(42))";
+    let p = parse_pattern(src).unwrap();
+    assert_eq!(p, Pattern::capture("cap_1", Pattern::number(42)));
+    assert_eq!(p.to_string(), src);
+}


### PR DESCRIPTION
## Summary
- add tests for nested capture parsing and variant names
- create new tests covering capture pattern matching via parse_pattern

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685313cd42448325adfb1867d1c9041a